### PR TITLE
Improve error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ php-unserializer
 ========================
 This is a library for parsing [php-serialized](http://php.net/manual/en/function.serialize.php) data to [scala](http://scala-lang.org/) object.
 
+For [SBT](http://www.scala-sbt.org/), add the following to your build file.
+
+```scala
+libraryDependencies += "com.sandinh" % "php-unserializer_2.10" % "1.0.1"
+```
+
 ### Sample usage
 (This is my real usage)
 
@@ -31,6 +37,9 @@ assert(validate("cƯỜnG Ẩ Ẵ Ự:;\""))
 
 ### Changelogs
 We use [Semantic Versioning](http://semver.org), so changing in micro version is binary compatible.
+
+##### v1.0.2
+Improved exception handling.
 
 ##### v1.0.1
 Add PhpUnserializer#parse(Array[Byte])

--- a/build.sbt
+++ b/build.sbt
@@ -55,4 +55,11 @@ pomExtra := (
       <id>forpdfsending</id>
       <email>forpdfsending@gmail.com</email>
     </developer>
+    <developer>
+      <id>giabao</id>
+      <name>Aaron S. Hawley</name>
+      <email>aaron.s.hawley@gmail.com</email>
+      <organization>NinthFloor.org</organization>
+      <organizationUrl>http://users.ninthfloor.org/~ashawley/</organizationUrl>
+    </developer>
   </developers>)

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ pomExtra := (
       <email>forpdfsending@gmail.com</email>
     </developer>
     <developer>
-      <id>giabao</id>
+      <id>ashawley</id>
       <name>Aaron S. Hawley</name>
       <email>aaron.s.hawley@gmail.com</email>
       <organization>NinthFloor.org</organization>


### PR DESCRIPTION
```
* src/test/scala/com/sandinh/phpparser/PhpUnserializerSpec.scala
(parse bool): Add corner case when empty.
(not parse invalid bool)
(not parse invalid int)
(not parse invalid float)
(not parse the empty string)
(not parse an invalid string)
(not parse string when length is missing)
(not parse when string is missing)
(not parse invalid array)
(not parse array when length is missing)
(parse empty array)
(not parse array when values missing)
(parse stdClass)
(not parse invalid object)
(not parse when object length is missing)
(not parse when object is missing): New tests.

* src/main/scala/com/sandinh/phpparser/PhpUnserializer.scala
(parse): Add exception handling.
(parseDelimiter): New method.
(parseBoolean,parseFloat,parseInt,readLength): Use parseDelimiter.
(parseString,parseObject): Add exception handling.
```
